### PR TITLE
Add support for 16KB pages on Android.

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -81,6 +81,7 @@ LOCAL_C_INCLUDES   := $(CORE_DIR)/include
 LOCAL_CFLAGS       := $(CFLAGS)
 LOCAL_CPPFLAGS     := $(CFLAGS)
 LOCAL_LDFLAGS      := $(LDFLAGS) #-Wl,-version-script=$(CORE_DIR)/libretro/link.T
+LOCAL_LDFLAGS      += -Wl,-z,max-page-size=16384
 LOCAL_LDLIBS       := -llog
 LOCAL_CPP_FEATURES := rtti
 LOCAL_ARM_MODE     := arm


### PR DESCRIPTION
Since last year Google is requiring every application on Google Play to support 16KB pages: https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html

It's a tiny build script change, I've tested it locally and it's working fine.

We did a test pilot with fceumm (https://github.com/libretro/libretro-fceumm/pull/644) and now I'm creating all the PRs for the other cores.