### PR TITLE
Opcodes fix

### DIFF
--- a/src/cpu/core_dynrec/decoder_opcodes.h
+++ b/src/cpu/core_dynrec/decoder_opcodes.h
@@ -1189,7 +1189,7 @@ static void dyn_ret_near(Bitu bytes) {
 		gen_call_function_raw((void*)&dynrec_pop_word);
 		gen_extend_word(false,FC_RETOP);
 	}
-	gen_mov_word_from_reg(FC_RETOP,decode.big_op?(void*)(&reg_eip):(void*)(&reg_ip),true);
+	gen_mov_word_from_reg(FC_RETOP,decode.big_op?(void*)(&reg_eip):(void*)(&reg_ip),decode.big_op);
 
 	if (bytes) gen_add_direct_word(&reg_esp,bytes,true);
 	dyn_return(BR_Normal);


### PR DESCRIPTION
The original parameter was `true` (32-bit store), but in 16-bit the destination is `&reg_ip`, which is only 16 bits. It worked accidentally in little-endian (the low bytes of the store fall onto reg_ip); in big-endian (XBOX360/XENON) `&reg_ip = &reg_ip+2`, so a 32-bit stw overwrites reg_ip with 0 (the MSBs of the extended value) and overflows into the next field of cpu_regs. Consequence: RET jumps to the upper half of the popped value (=0) instead of the lower half (= return real address). Symptom observed in PoP 1: RET after CALL E8 jumped to CS:0000 instead of the true return address.