### PR TITLE
MIXER_CallBack: guard empty buffer (len==0) to avoid modulo-by-zero UB

### DIFF
--- a/src/hardware/mixer.cpp
+++ b/src/hardware/mixer.cpp
@@ -580,6 +580,11 @@ static void SDLCALL
 void
 #endif
 MIXER_CallBack(void * /*userdata*/, uint8_t *stream, int len) {
+	/* An empty buffer (len==0) makes need==0, so `index_add % need` below is a
+	 * modulo-by-zero (undefined behavior) -- observed to miscompile into an
+	 * out-of-bounds store under clang -O2 on arm64 (SIGSEGV during boot on
+	 * locally-built cores). There is nothing to mix into an empty buffer anyway. */
+	if (len <= 0) return;
 	Bitu need=(Bitu)len/MIXER_SSIZE;
 	Bit16s * output=(Bit16s *)stream;
 	Bitu reduce;


### PR DESCRIPTION
When MIXER_CallBack is invoked with len==0, need = len/MIXER_SSIZE becomes 0 and the following `index = (index_add % need) ? need : 0` is a modulo-by-zero, which is undefined behavior. Under clang -O2 on arm64 (Apple Silicon) this miscompiles into an out-of-bounds store and SIGSEGVs during DOS boot on locally-built cores (the official libretro buildbot nightly, built with a different toolchain, is unaffected). An empty buffer has nothing to mix, so return early.